### PR TITLE
Bugfix

### DIFF
--- a/Dumbledroid/src/io/leocad/dumbledroid/data/cache/FileController.java
+++ b/Dumbledroid/src/io/leocad/dumbledroid/data/cache/FileController.java
@@ -51,8 +51,8 @@ public class FileController {
 
 			if (!file.exists()) {
 				file.createNewFile();
-				fos = new FileOutputStream(file);
 			}
+			fos = new FileOutputStream(file);
 
 		} else {
 			fos = mContext.openFileOutput(filename, Context.MODE_WORLD_READABLE | Context.MODE_WORLD_WRITEABLE);


### PR DESCRIPTION
Moved the instantiation of the FileOutputStream that was causing
NullPointerException when the file was already created.
