### PR TITLE
Autorenew cache time if headers show no change.

### DIFF
--- a/Dumbledroid/src/io/leocad/dumbledroid/data/DataController.java
+++ b/Dumbledroid/src/io/leocad/dumbledroid/data/DataController.java
@@ -67,7 +67,8 @@ public class DataController {
 
 				if ( modelHolder != null && lastModTimeMillis <= modelHolder.timestamp && ObjectCopier.copy(modelHolder.model, receiver)) {
 
-					//Discard the connection and return the cached version
+					//Discard the connection and return the cached version renewing the timestamp
+					modelHolder.timestamp = System.currentTimeMillis()
 					return;
 				}
 			}


### PR DESCRIPTION
ModelHolder's timestamp should renew when model expires but the requested headers for last-modify show no modification with respect to the cached version.
